### PR TITLE
Update code example in README following renderTime changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ const po = new PerformanceObserver(list => {
     const entries = list.getEntries();
     const entry = entries[entries.length - 1];
     // Use the startTime, which will be the later of renderTime or loadTime.
-    // Note: Most browser suppot a coarsened renderTime for cross-origin
+    // Note: Most browser support a coarsened renderTime for cross-origin
     // resources, rather than needing to fallback to loadTime.
     const largestPaintTime = entry.startTime;
     // Send the LCP information for processing.


### PR DESCRIPTION
A non-zero `entry.renderTime` is no longer a signal for accurate LCP since browsers (Chrome and Firefox) now give a coarsened render time instead of falling back to load time.