### PR TITLE
Fix #135: report one candidate per paint

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -131,17 +131,12 @@ following members:
 * <dfn for="largest contentful paint candidate">request</dfn>, a [=/Request=] or null
 * <dfn for="largest contentful paint candidate">loadTime</dfn>, a [=/number=]
 
-An [=largest contentful paint candidate=] |candidate| is <dfn>eligible to be largest contentful paint</dfn> if it meets the
-following criteria:
-
-* |candidate|'s [=largest contentful paint candidate/element=]'s opacity is > 0
-* |candidate|'s [=largest contentful paint candidate/element=] is a text node, or |candidate|'s [=largest contentful paint candidate/request=]'s
-    [=/response=]'s content length in bytes is >= |candidate|'s [=largest contentful paint candidate/element=]'s [=effective visual size=] * 0.004
-
-    Note: This heuristic tests whether the image resource contains sufficient data to be seen as contentful to the user. It compares the transferred file size with the number of pixels which are actually produced, after decoding and any image scaling is applied. Images which encode a very large number of pixels with in a very small number of bytes are typically low-content backgrounds, gradients, and the like, and are not considered as [=largest contentful paint candidates=].
 
 Largest Contentful Paint {#sec-largest-contentful-paint}
 =======================================
+
+Note: A user agent implementing the Largest Contentful Paint API would need to include <code>"largest-contentful-paint"</code> in {{PerformanceObserver/supportedEntryTypes}} for {{Window}} contexts.
+This allows developers to detect support for the API.
 
 Largest Contentful Paint involves the following new interface:
 
@@ -197,9 +192,6 @@ The {{LargestContentfulPaint/element}} attribute's getter must perform the follo
 Note: The above algorithm defines that an element that is no longer a [=tree/descendant=] of the {{Document}} will no longer be returned by {{LargestContentfulPaint/element}}'s attribute getter, including elements that are inside a shadow DOM.
 
 This specification also extends {{Document}} by adding to it a <dfn>largest contentful paint size</dfn> concept, initially set to 0.
-It also adds an associated <dfn>content set</dfn>, which is initially an empty <a spec=infra for=/>set</a>. The [=content set=] will be filled with ({{Element}}, {{Request}}) <a>tuples</a>. This is used for performance, to enable the algorithm to only consider each content once.
-
-Note: The user agent needs to maintain the [=content set=] so that removed content does not introduce memory leaks. In particular, it can tie the lifetime of the <a>tuples</a> to weak pointers to the {{Element|Elements}} so that it can be cleaned up sometime after the {{Element|Elements}} are removed. Since the <a spec=infra for=/>set</a> is not exposed to web developers, this does not expose garbage collection timing.
 
 Processing model {#sec-processing-model}
 ========================================
@@ -220,36 +212,40 @@ Modifications to the DOM specification {#sec-modifications-DOM}
     * If |target|'s [=relevant global object=] is a {{Window}} object, <var ignore>event</var>'s {{Event/type}} is {{Document/scroll}} and its {{Event/isTrusted}} is true, set |target|'s [=relevant global object=]'s [=has dispatched scroll event=] to true.
 </div>
 
+
 Report Largest Contentful Paint {#sec-report-largest-contentful-paint}
 ----------------------------------------------------------------------
 
 <div export algorithm="report largest contentful paint">
     When asked to <dfn>report largest contentful paint</dfn> given a {{Document}} |document|, a [=PaintTimingMixin/paint timing info=] |paintTimingInfo|, an [=ordered set=] of [=pending image records=] |paintedImages|, and an [=ordered set=] of [=/elements=] |paintedTextNodes|, perform the following steps:
 
+        Note: Each pending image record in |paintedImages| and text element in |paintedTextNodes| will only be reported exactly once, from [=mark paint timing=], for the first paint where the element is considered paintable (i.e. has opacity and visibility) and contentful (i.e. image resource or blocking fonts are sufficiently loaded).
+
+    1. Let |window| be |document|’s [=relevant global object=].
+    1. If either of |window|'s [=has dispatched scroll event=] or [=has dispatched input event=] is true, return.
     1. Let |newCandidateSize| be |document|'s [=largest contentful paint size=].
     1. Let |newCandidate| be null.
     1. [=list/For each=] |record| of |paintedImages|:
         1. Let |imageElement| be |record|'s [=pending image record/element=].
         1. If |imageElement| is not [=exposed for paint timing=], given |document|, continue.
         1. Let |intersectionRect| be the value returned by the intersection rect algorithm using |imageElement| as the target and viewport as the root.
-        1. Let |size| be the [=effective visual size=] of |imageElement| given |intersectionRect|.
+        1. Let |size| be the [=effective visual size=] of |imageElement| given |intersectionRect| and |record|'s [=pending image record/request=].
         1. If |size| is less than or equal to |newCandidateSize|, continue.
-        1. Let |request| be |record|'s [=pending image record/request=].
         1. Set |newCandidateSize| to |size|.
-        1. Set |newCandidate| to be a new [=largest contentful paint candidate=] with its [=largest contentful paint candidate/element=] set to |imageElement|, its [=largest contentful paint candidate/size=] set to |size|, its [=largest contentful paint candidate/request=] set to |request|, and its [=largest contentful paint candidate/loadTime=] set to |record|'s [=pending image record/loadTime=].
+        1. Set |newCandidate| to be a new [=largest contentful paint candidate=] with its [=largest contentful paint candidate/element=] set to |imageElement|, its [=largest contentful paint candidate/size=] set to |size|, its [=largest contentful paint candidate/request=] set to |record|'s [=pending image record/request=], and its [=largest contentful paint candidate/loadTime=] set to |record|'s [=pending image record/loadTime=].
     1. [=list/For each=] |textNode| of |paintedTextNodes|,
         1. If |textNode| is not [=exposed for paint timing=], given |document|, continue.
         1. If |textNode| has [=alpha channel=] value <=0 or [=opacity=] value <=0:
             1. If |textNode|'s <a property>text-shadow</a> value is none, |textNode|'s 'stroke-color' value is [=transparent=] and |textNode|'s 'stroke-image' value is none, continue.
-        1. Let |intersectionRect| be the union of the border boxes of all {{Text}} <a>nodes</a> in |textNode|'s <a>set of owned text nodes</a>.
-        1. Intersect |intersectionRect| with the visual viewport.
-        1. Let |size| be the [=effective visual size=] of |textNode| given |intersectionRect|.
+        1. Let |intersectionRect| be the union of the border boxes of all {{Text}} <a>nodes</a> in |textNode|'s <a>set of owned text nodes</a>, intersected with the visual viewport.
+        1. Let |size| be the [=effective visual size=] of |textNode| given |intersectionRect| and null.
         1. If |size| is less than or equal to |newCandidateSize|, continue.
         1. Set |newCandidateSize| to |size|.
         1. Set |newCandidate| to be a new [=largest contentful paint candidate=] with its [=largest contentful paint candidate/element=] set to |textNode|, its [=largest contentful paint candidate/size=] set to |size|, its [=largest contentful paint candidate/request=] set to null, and its [=largest contentful paint candidate/loadTime=] set to 0.
     1. If |newCandidate| is not null:
-        1. <a>Potentially add a LargestContentfulPaint entry</a> with |newCandidate|, |paintTimingInfo|, and |document|.
+        1. <a>Create a LargestContentfulPaint entry</a> with |newCandidate|, |paintTimingInfo|, and |document|.
 </div>
+
 
 Determine the effective visual size of an element {#sec-effective-visual-size}
 ------------------------------------------------------------------------------
@@ -260,7 +256,7 @@ run the following steps:
 <div algorithm="LargestContentfulPaint effective-visual-size">
     : Input
     ::  |intersectionRect|, a {{DOMRectReadOnly}}
-    ::  |imageRequest|, a {{Request}}
+    ::  |imageRequest|, a {{Request}} or null
     ::  |element|, an [=/Element=]
     ::  |document|, a <a>Document</a>
     : Output
@@ -272,8 +268,12 @@ run the following steps:
         1. Let |rootWidth| be |root|'s <a>visual viewport</a>'s width, excluding any scrollbars.
         1. Let |rootHeight| be |root|'s <a>visual viewport</a>'s height, excluding any scrollbars.
         1. If |size| is equal to |rootWidth| times |rootHeight|, return null.
-        1. If |imageRequest| is not [=eligible to be largest contentful paint=], return null.
+
         1. If |imageRequest| is not null, run the following steps to adjust for image position and upscaling:
+            1. If |imageRequest|'s [=/response=]'s content length in bytes is less than |size| * 0.004, then return null.
+                
+                Note: This heuristic tests whether the image resource contains sufficient data to be seen as contentful to the user. It compares the transferred file size with the number of pixels which are actually produced, after decoding and any image scaling is applied. Images which encode a very large number of pixels with in a very small number of bytes are typically low-content backgrounds, gradients, and the like, and are not considered as LCP candidates.
+
             1. Let |concreteDimensions| be |imageRequest|'s [=concrete object size=] within |element|.
             1. Let |visibleDimensions| be |concreteDimensions|, adjusted for positioning by 'object-position' or 'background-position' and |element|'s [=content box=].
 
@@ -283,7 +283,7 @@ run the following steps:
             1. Let |intersectingClientContentRect| be the intersection of |clientContentRect| with |intersectionRect|.
             1. Set |size| to <code>|intersectingClientContentRect|'s {{DOMRectReadOnly/width}} * |intersectingClientContentRect|'s {{DOMRectReadOnly/height}}</code>.
 
-               Note: this ensures that we only intersect with the image itself and not with the element's decorations.
+               Note: This ensures that we only intersect with the image itself and not with the element's decorations.
 
             1. Let |naturalArea| be <code>|imageRequest|'s [=natural width=] * |imageRequest|'s [=natural height=]</code>.
             1. If |naturalArea| is 0, then return null.
@@ -294,35 +294,6 @@ run the following steps:
         1. Return |size|.
 </div>
 
-Potentially add LargestContentfulPaint entry {#sec-add-lcp-entry}
------------------------------------------------------------------
-
-Note: A user agent implementing the Largest Contentful Paint API would need to include <code>"largest-contentful-paint"</code> in {{PerformanceObserver/supportedEntryTypes}} for {{Window}} contexts.
-This allows developers to detect support for the API.
-
-In order to <dfn export>potentially add a {{LargestContentfulPaint}} entry</dfn>, the user agent must run the following steps:
-<div algorithm="LargestContentfulPaint potentially-add-entry">
-    : Input
-    ::  |candidate|, a [=largest contentful paint candidate=]
-    ::  |paintTimingInfo|, a [=PaintTimingMixin/paint timing info=]
-    ::  |document|, a <a>Document</a>
-    : Output
-    ::  None
-        1. If |document|'s [=content set=] <a for=set>contains</a> |candidate|, return.
-        1. <a for=set>Append</a> |candidate| to |document|'s [=content set=]
-        1. Let |window| be |document|’s [=relevant global object=].
-        1. If either of |window|'s [=has dispatched scroll event=] or [=has dispatched input event=] is true, return.
-        1. Let |contentInfo| be a <a>map</a>.
-        1. Set |contentInfo|["size"] to |candidate|'s [=largest contentful paint candidate/size=].
-        1. Let |url| be the empty string.
-        1. If |candidate|'s [=largest contentful paint candidate/request=] is not null, set |url| to be |candidate|'s [=largest contentful paint candidate/request=]'s [=request URL=].
-        1. Set |contentInfo|["url"] = |url|.
-        1. Set |contentInfo|["id"] to |candidate|'s [=largest contentful paint candidate/element=]'s <a attribute for=Element>element id</a>.
-        1. Set |contentInfo|["loadTime"] to |candidate|'s [=largest contentful paint candidate/loadTime=].
-        1. Set |contentInfo|["element"] to |candidate|'s [=largest contentful paint candidate/element=].
-        1. <a>Create a LargestContentfulPaint entry</a> with |contentInfo|, |paintTimingInfo|, and |document| as inputs.
-</div>
-
 Create a LargestContentfulPaint entry {#sec-create-entry}
 --------------------------------------------------------
 
@@ -330,18 +301,20 @@ In order to <dfn>create a {{LargestContentfulPaint}} entry</dfn>, the user agent
 
 <div algorithm="LargestContentfulPaint create-entry">
     : Input
-    ::  |contentInfo|, a <a>map</a>
+    ::  |candidate|, a [=largest contentful paint candidate=]
     ::  |paintTimingInfo|, a [=PaintTimingMixin/paint timing info=]
     ::  |document|, a {{Document}}
     : Output
     ::  None
-        1. Set |document|'s [=largest contentful paint size=] to |contentInfo|["size"].
+        1. Set |document|'s [=largest contentful paint size=] to |candidate|'s [=largest contentful paint candidate/size=].
+        1. Let |url| be the empty string.
+        1. If |candidate|'s [=largest contentful paint candidate/request=] is not null, set |url| to be |candidate|'s [=largest contentful paint candidate/request=]'s [=request URL=].
         1. Let |entry| be a new {{LargestContentfulPaint}} entry with |document|'s [=relevant realm=], whose [=PaintTimingMixin/paint timing info=] is |paintTimingInfo|, with its
-            * {{LargestContentfulPaint/size}} set to |contentInfo|["size"],
-            * {{LargestContentfulPaint/url}} set to |contentInfo|["url"],
-            * {{LargestContentfulPaint/id}} set to |contentInfo|["id"],
-            * {{LargestContentfulPaint/loadTime}} set to |contentInfo|["loadTime"],
-            * and {{LargestContentfulPaint/element}} set to |contentInfo|["element"].
+            * {{LargestContentfulPaint/size}} set to |candidate|'s [=largest contentful paint candidate/size=],
+            * {{LargestContentfulPaint/url}} set to |url|,
+            * {{LargestContentfulPaint/id}} set to |candidate|'s [=largest contentful paint candidate/element=]'s <a attribute for=Element>element id</a>,
+            * {{LargestContentfulPaint/loadTime}} set to |candidate|'s [=largest contentful paint candidate/loadTime=],
+            * and {{LargestContentfulPaint/element}} set to |candidate|'s [=largest contentful paint candidate/element=].
         1. [=Queue the PerformanceEntry=] |entry|.
 </div>
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmocny/largest-contentful-paint/pull/154.html" title="Last updated on Nov 19, 2025, 10:23 AM UTC (a022810)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/largest-contentful-paint/154/475d962...mmocny:a022810.html" title="Last updated on Nov 19, 2025, 10:23 AM UTC (a022810)">Diff</a>