### PR TITLE
[lcp]: Fix spec wording to make renderTime non-optional.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -169,7 +169,7 @@ The {{PerformanceEntry/entryType}} attribute's getter must return the {{DOMStrin
 
 The {{PerformanceEntry/name}} attribute's getter must return the empty string.
 
-The {{PerformanceEntry/startTime}} attribute's getter must return the value of [=this=]'s {{LargestContentfulPaint/renderTime}} if it is not 0, and the value of [=this=]'s [=LargestContentfulPaint/loadTime=] otherwise.
+The {{PerformanceEntry/startTime}} attribute's getter must return the value of [=this=]'s {{LargestContentfulPaint/renderTime}}.
 
 The {{PerformanceEntry/duration}} attribute's getter must return 0.
 


### PR DESCRIPTION
The LCP spec still had wording that implied that renderTime could be 0, which it can no longer be.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmocny/largest-contentful-paint/pull/164.html" title="Last updated on Mar 19, 2026, 6:27 PM UTC (83dcca8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/largest-contentful-paint/164/3baa731...mmocny:83dcca8.html" title="Last updated on Mar 19, 2026, 6:27 PM UTC (83dcca8)">Diff</a>