### PR TITLE
Fix Sequence for Sub-Steps for Step 8 of `4.3. Determine the effectie visual size of an element`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -288,13 +288,13 @@ run the following steps:
             1. Let |concreteDimensions| be |imageRequest|'s [=concrete object size=] within |element|.
             1. Let |visibleDimensions| be |concreteDimensions|, adjusted for positioning by 'object-position' or 'background-position' and |element|'s [=content box=].
 
-               Note: some of those algorithms are not rigorously defined in CSS. The expected result is to get the actual position and size of the image in |element| as a {{DOMRectReadOnly}}.
+                Note: some of those algorithms are not rigorously defined in CSS. The expected result is to get the actual position and size of the image in |element| as a {{DOMRectReadOnly}}.
 
             1. Let |clientContentRect| be the smallest {{DOMRectReadOnly}} containing |visibleDimensions| with |element|'s [=transforms=] applied.
             1. Let |intersectingClientContentRect| be the intersection of |clientContentRect| with |intersectionRect|.
             1. Set |size| to <code>|intersectingClientContentRect|'s {{DOMRectReadOnly/width}} * |intersectingClientContentRect|'s {{DOMRectReadOnly/height}}</code>.
 
-               Note: This ensures that we only intersect with the image itself and not with the element's decorations.
+                Note: This ensures that we only intersect with the image itself and not with the element's decorations.
 
             1. Let |naturalArea| be <code>|imageRequest|'s [=natural width=] * |imageRequest|'s [=natural height=]</code>.
             1. If |naturalArea| is 0, then return null.


### PR DESCRIPTION
Just adding a space corrects the order.

Closes: #167


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shubhamg13/largest-contentful-paint/pull/169.html" title="Last updated on Mar 26, 2026, 5:17 AM UTC (8a54a3e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/largest-contentful-paint/169/650d296...shubhamg13:8a54a3e.html" title="Last updated on Mar 26, 2026, 5:17 AM UTC (8a54a3e)">Diff</a>