### PR TITLE
Correct indentation for setting paintedImages as newCandidate

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -253,13 +253,13 @@ Report Largest Contentful Paint {#sec-report-largest-contentful-paint}
         1. If |result| is null, continue.
         1. If |result|'s [=effective visual size result/size=] is less than or equal to |largestSize|, continue.
         1. Set |largestSize| to |result|'s [=effective visual size result/size=].
-    1. Set |newCandidate| to be a new [=largest contentful paint candidate=] with the following values:
-        1. [=largest contentful paint candidate/element=] set to |imageElement|.
-        1. [=largest contentful paint candidate/size=] set to |result|'s [=effective visual size result/size=].
-        1. [=largest contentful paint candidate/width=] set to |result|'s [=effective visual size result/width=].
-        1. [=largest contentful paint candidate/height=] set to |result|'s [=effective visual size result/height=].
-        1. [=largest contentful paint candidate/request=] set to |record|'s [=pending image record/request=].
-        1. [=largest contentful paint candidate/loadTime=] set to |record|'s [=pending image record/loadTime=].
+        1. Set |newCandidate| to be a new [=largest contentful paint candidate=] with the following values:
+            1. [=largest contentful paint candidate/element=] set to |imageElement|.
+            1. [=largest contentful paint candidate/size=] set to |result|'s [=effective visual size result/size=].
+            1. [=largest contentful paint candidate/width=] set to |result|'s [=effective visual size result/width=].
+            1. [=largest contentful paint candidate/height=] set to |result|'s [=effective visual size result/height=].
+            1. [=largest contentful paint candidate/request=] set to |record|'s [=pending image record/request=].
+            1. [=largest contentful paint candidate/loadTime=] set to |record|'s [=pending image record/loadTime=].
     1. [=list/For each=] |textNode| of |paintedTextNodes|,
         1. If |textNode| is not [=exposed for paint timing=], given |document|, continue.
         1. If |textNode| has [=alpha channel=] value <=0 or [=opacity=] value <=0:
@@ -313,7 +313,7 @@ run the following steps:
             1. Let |concreteDimensions| be |imageRequest|'s [=concrete object size=] within |element|.
             1. Let |visibleDimensions| be |concreteDimensions|, adjusted for positioning by 'object-position' or 'background-position' and |element|'s [=content box=].
 
-                Note: some of those algorithms are not rigorously defined in CSS. The expected result is to get the actual position and size of the image in |element| as a {{DOMRectReadOnly}}.
+                Note: Some of those algorithms are not rigorously defined in CSS. The expected result is to get the actual position and size of the image in |element| as a {{DOMRectReadOnly}}.
 
             1. Let |clientContentRect| be the smallest {{DOMRectReadOnly}} containing |visibleDimensions| with |element|'s [=transforms=] applied.
             1. Let |intersectingClientContentRect| be the intersection of |clientContentRect| with |intersectionRect|.


### PR DESCRIPTION
This just adds indentation to steps


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shubhamg13/largest-contentful-paint/pull/170.html" title="Last updated on Jun 1, 2026, 4:26 PM UTC (6048045)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/largest-contentful-paint/170/78ab2c3...shubhamg13:6048045.html" title="Last updated on Jun 1, 2026, 4:26 PM UTC (6048045)">Diff</a>